### PR TITLE
fix links to obs data

### DIFF
--- a/doc/User_Manual/VERDI_ch06.md
+++ b/doc/User_Manual/VERDI_ch06.md
@@ -24,9 +24,13 @@ VERDI can use observational data in either using ASCII file or created using Mod
 
 Observational data in ASCII format can be obtained from many data sources. Data can be downloaded 
 from the CMAS Center Google Drive 
-(https://drive.google.com/drive/u/1/folders/1YIcmYtPH_DRyN51dDEQDh3r5Q_4iNLuu) 
+
+<li><https://drive.google.com/drive/u/1/folders/1YIcmYtPH_DRyN51dDEQDh3r5Q_4iNLuu></li>
+
 or  EPA’s Remote Sensing Information Gateway - RSIG
-(<https://www.epa.gov/hesc/remote-sensing-information-gateway>). 
+
+<li><https://www.epa.gov/hesc/remote-sensing-information-gateway></li>
+
 To use a consistent set of units for the model data and the observational data, you may need to import the ASCII data into a tool (e.g., a spreadsheet or database program) and perform a unit conversion. VERDI doesn’t allow the user to use an observational variable to create a formula, so conversions to different units must be performed before loading the data into VERDI.
 
 <!-- BEGIN COMMENT -->


### PR DESCRIPTION
updating PDF to fix VERDI users’ manual have two lines run-over the page on Page 27 below 6.1.2 Observational Data Formats.