### PR TITLE
update release notes in two locations

### DIFF
--- a/doc/Release_Notes/README.md
+++ b/doc/Release_Notes/README.md
@@ -2,6 +2,10 @@
 RELEASE NOTES FOR VERDI 2.1.5
 -----------------------------
 
+**REPLACE ALL PRIOR** versions of VERDI with this patched release version.
+
+*Updated OpenJDK to version 21 to fix security vulnerability.
+
 The following new features were added:
 
 * Open and display a MPAS Mesh File (#324)

--- a/verdi_dist/distfiles/RELEASE-NOTES.txt
+++ b/verdi_dist/distfiles/RELEASE-NOTES.txt
@@ -1,10 +1,44 @@
 -----------------------------
+RELEASE NOTES FOR VERDI 2.1.5
+-----------------------------
+
+**REPLACE ALL PRIOR** versions of VERDI with this patched release version.
+
+*Updated OpenJDK to version 21 to fix security vulnerability.
+
+The following new features were added:
+
+* Open and display a MPAS Mesh File (#324)
+* Documentation on how to visualize fine scale model output datafiles with GIS layers
+* Support sub-domain on a Vertical Cross Section Plot from the command line (#326)
+
+The following issues were fixed.
+
+* Save tile plot as shapefile from GUI (#322)
+* Tile Plot Statistics for MPAS (#255)
+* Enable "Metadata Me" for MPAS (#320)
+* Saving and Opening a Project (#318)
+
+
+-----------------------------
 RELEASE NOTES FOR VERDI 2.1.4
 -----------------------------
 
 **REPLACE ALL PRIOR** versions of VERDI with this patched release version.
 
 *Updated OpenJDK to version 17.0.2 to fix security vulnerability: https://openjdk.java.net/groups/vulnerability/advisories/2021-10-19
+
+The following issues were fixed.
+
+* Ability to display 3-D contour plot (#184, #304)
+
+* Ability to display “zgrid” tile plot for MPAS dataset (#257)
+
+* Allow user to modify scatter plot dot size (#260)
+
+* Allow animate plot to be exported as .mp4 movie format (#270)
+
+*  Fix Tile Plot Legend Placement (#307)
 
 -----------------------------
 RELEASE NOTES FOR VERDI 2.1.3


### PR DESCRIPTION
added jdk version 21 to the release notes in two locations (one for github site, other for the verdi packages).